### PR TITLE
Bump base-dev image

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -1,6 +1,6 @@
 # influenced by the official docker ruby env
 # https://github.com/docker-library/ruby/blob/master/2.0/Dockerfile
-FROM quay.io/orgsync/base-dev:1.0.1
+FROM quay.io/orgsync/base-dev:1.1.0
 MAINTAINER Joshua Griffith <joshua@orgsync.com>
 
 # install ruby


### PR DESCRIPTION
Connects to https://github.com/orgsync/docker-base/pull/1 and https://github.com/orgsync/base-dev/pull/1 